### PR TITLE
Tax Free Levels 1.3 compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@ org.gradle.jvmargs=-Xmx1G
     archives_base_name = grind-enchantments
 
 # Dependencies
-    tax_free_levels_version=eb2d25c
+    tax_free_levels_version=91a04eb

--- a/src/main/java/de/martenschaefer/grindenchantments/GrindEnchantments.java
+++ b/src/main/java/de/martenschaefer/grindenchantments/GrindEnchantments.java
@@ -16,7 +16,7 @@ import net.minecraft.world.World;
 import net.fabricmc.loader.api.FabricLoader;
 import de.martenschaefer.grindenchantments.config.EnchantmentCostConfig;
 import de.martenschaefer.grindenchantments.config.GrindEnchantmentsConfig;
-import fourmisain.taxfreelevels.TaxFreeLevels;
+import io.github.fourmisain.taxfreelevels.TaxFreeLevels;
 
 public class GrindEnchantments {
     public static int getLevelCost(ItemStack itemStack1, ItemStack itemStack2) {
@@ -71,7 +71,7 @@ public class GrindEnchantments {
                 int cost = getLevelCost(enchantedItemStack, bookItemStack);
 
                 if (FabricLoader.getInstance().isModLoaded("taxfreelevels"))
-                    player.addExperience(-TaxFreeLevels.getXpDifference(player, 0, cost));
+                    TaxFreeLevels.applyFlattenedXpCost(player, cost);
                 else
                     player.addExperienceLevels(-cost);
             }
@@ -199,8 +199,7 @@ public class GrindEnchantments {
 
             if (!player.getAbilities().creativeMode) {
                 if (FabricLoader.getInstance().isModLoaded("taxfreelevels"))
-                    player.addExperience(-TaxFreeLevels.getXpDifference(player, 0,
-                        GrindEnchantments.getLevelCost(itemStack1, itemStack2)));
+                    TaxFreeLevels.applyFlattenedXpCost(player, GrindEnchantments.getLevelCost(itemStack1, itemStack2));
                 else
                     player.addExperienceLevels(-GrindEnchantments.getLevelCost(itemStack1, itemStack2));
             }


### PR DESCRIPTION
1.3 changed quite a few things, especially reworking the anvil costs.
This will make sure it'll use the new formula and it also mitigates the side effects of using `addExperience` (which affects the player's score and the `XP` scoreboard criterion).

For anyone else reading: I've went ahead and made an [inofficial build](https://github.com/Fourmisain/grind-enchantments/releases/tag/1.4.0-TaxFreeLevels) (for Minecraft 1.17 and 1.18) for the meantime.

P.S.
Not sure why but JitPack [failed](https://jitpack.io/com/github/Fourmisain/TaxFreeLevels/1.3/build.log) when setting the target version to `1.3`, it built it, just couldn't find the artifacts - using the commit hash instead [worked](https://jitpack.io/com/github/Fourmisain/TaxFreeLevels/91a04ebd70/build.log) without a flaw, weird.